### PR TITLE
Replaced ambisonics.umd.js with dist/index.js in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "email": "David.Poirier-Quinot@ircam.fr"
     }
   ],
-  "main": "ambisonics.umd.js",
+  "main": "dist/index.js",
   "standalone": "ambisonics",
   "scripts": {
     "bundle": "node ./bin/runner --bundle",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "ambisonics.umd.js",
     "ambisonics.min.js",
     "src/",
-    "bin/"
+    "bin/",
+    "dist/"
   ]
 }


### PR DESCRIPTION
Replaced ambisonics.umd.js with dist/index.js in the "main" field of package.json (bundles will be used by <script> person, let's point directly to the sources for the npm people!). If you see no objection polarch?
