### PR TITLE
Changed the path dependence to serve-sofa-href

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-runtime": "^6.6.1",
     "get-float-time-domain-data": "^0.1.0",
     "numeric": "^1.2.6",
-    "serve-sofa-hrtf": "git://github.com/Ircam-RnD/serveSofaHrir",
+    "serve-sofa-hrtf": "Ircam-RnD/serveSofaHrir",
     "spherical-harmonic-transform": "^0.1.0",
     "convex-hull": "^1.0.3"
   },


### PR DESCRIPTION
The path for the "serve-soft-hrtg" was problematic for me when using "npm install ambisonics". Github repos can be used directly using the username and repo, hence "Ircam-Rnd/serveSofaHrir" (but you might know that). The previous way led to npm ERR for me, maybe its just the network I'm on, but with the change on my fork, I was able to install the package using "npm install renaudfv/JSAmbisonics". I can send you the error log or the saved session from the Terminal if needed.
