### PR TITLE
NPM module main entry file

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,19 @@ To add the library to you node project, type in (terminal at project root):
 npm install ambisonics
 ```
 
-To use the ambisonic objects, include the JSAmbisonics library in the body of your html code as:
+##### CommonJS (browserify)
+
+To use directly from node modules
+
 ```javascript
+var ambisonics = require('ambisonics');
+```
+
+##### Global
+
+To use the ambisonic objects globally, include the JSAmbisonics library in the body of your html code as:
+
+```html
 <script type="text/javascript" src="ambisonics.umd.js"></script>
 ```
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-runtime": "^6.6.1",
     "get-float-time-domain-data": "^0.1.0",
     "numeric": "^1.2.6",
-    "serve-sofa-hrtf": "git://github.com/Ircam-RnD/serveSofaHrir",
+    "serve-sofa-hrtf": "Ircam-RnD/serveSofaHrir",
     "spherical-harmonic-transform": "^0.1.0",
     "convex-hull": "^1.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "email": "David.Poirier-Quinot@ircam.fr"
     }
   ],
-  "main": "ambisonics.umd.js",
+  "main": "dist/index.js",
   "standalone": "ambisonics",
   "scripts": {
     "bundle": "node ./bin/runner --bundle",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-runtime": "^6.6.1",
     "get-float-time-domain-data": "^0.1.0",
     "numeric": "^1.2.6",
-    "serve-sofa-hrtf": "Ircam-RnD/serveSofaHrir",
+    "serve-sofa-hrtf": "git://github.com/Ircam-RnD/serveSofaHrir",
     "spherical-harmonic-transform": "^0.1.0",
     "convex-hull": "^1.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "ambisonics.umd.js",
     "ambisonics.min.js",
     "src/",
-    "bin/"
+    "bin/",
+    "dist/index.js"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "ambisonics.min.js",
     "src/",
     "bin/",
-    "dist/index.js"
+    "dist/"
   ]
 }


### PR DESCRIPTION
*\* Duplicate from the other open pull request...

The main file config pointed to the bundle UMD file which was meant to be used as a global from HTML. 
This does not comply to the way node modules are typically used, especially when serve from NPM. Having the UMD file as an entry point leaded to not be able to call "require('ambisonics')" and expose to pre-browserified files. 
By using the dist transpiled file, developper can access the ambisonics classes/modules and bundle as they want, in a more common way. 

This should also be applied to the version on _NPM.js_. 
